### PR TITLE
Revert "Remove internationalization"

### DIFF
--- a/WikidataOrg.php
+++ b/WikidataOrg.php
@@ -58,8 +58,11 @@ $GLOBALS['wgExtensionFunctions'][] = function() {
 		'version' => WIKIDATA_ORG_VERSION,
 		'author' => '[https://www.mediawiki.org/wiki/User:Bene* Bene*]',
 		'url' => 'https://github.com/wmde/Wikidata.org',
-		'description' => 'Configuration for and customizations to Wikibase that are specific to wikidata.org'
+		'descriptionmsg' => 'wikidata-org-desc'
 	);
+
+	// i18n
+	$wgMessagesDirs['Wikidata.org'] = __DIR__ . '/i18n';
 
 	// Hooks
 	$wgHooks['BeforePageDisplay'][] = 'WikidataOrg\Hooks::onBeforePageDisplay';

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,8 @@
+{
+	"@metadata": {
+		"authors": [
+			"Bene*"
+		]
+	},
+	"wikidata-org-desc": "Configuration for and customizations to Wikibase that are specific to wikidata.org"
+}

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1,0 +1,8 @@
+{
+	"@metadata": {
+		"authors": [
+			"Bene*"
+		]
+	},
+	"wikidata-org-desc": "{{desc|name=Wikidata.org|url=https://github.com/wmde/Wikidata.org}}"
+}


### PR DESCRIPTION
Hardcoding English text is not the way to fix
messages not appearing.

This reverts commit e989be11908893b4abd9b1bb0fb393b6434f969e.
