### PR TITLE
Declare $wgMessagesDirs outside of $wgExtensionFunctions

### DIFF
--- a/WikidataOrg.php
+++ b/WikidataOrg.php
@@ -45,8 +45,10 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	include_once( __DIR__ . '/vendor/autoload.php' );
 }
 
+$GLOBALS['wgMessagesDirs']['Wikidata.org'] = __DIR__ . '/i18n';
+
 $GLOBALS['wgExtensionFunctions'][] = function() {
-	global $wgExtensionCredits, $wgMessagesDirs, $wgHooks, $wgResourceModules;
+	global $wgExtensionCredits, $wgHooks, $wgResourceModules;
 
 	if ( !defined( 'WB_VERSION' ) ) {
 		throw new Exception( 'The Wikidata.org extension requires Wikibase to be installed.' );
@@ -61,9 +63,6 @@ $GLOBALS['wgExtensionFunctions'][] = function() {
 		'descriptionmsg' => 'wikidata-org-desc',
 		'license-name' => 'GPL-2.0+'
 	);
-
-	// i18n
-	$wgMessagesDirs['Wikidata.org'] = __DIR__ . '/i18n';
 
 	// Hooks
 	$wgHooks['BeforePageDisplay'][] = 'WikidataOrg\Hooks::onBeforePageDisplay';


### PR DESCRIPTION
Needed for Wikimedia localization update (that doesn't execute
$wgExtensionFunctions)

See also: https://github.com/wmde/WikimediaBadges/pull/13
