### PR TITLE
Fix selectors for badge icons

### DIFF
--- a/resources/themes/default/wikidata-org.badges.css
+++ b/resources/themes/default/wikidata-org.badges.css
@@ -11,7 +11,7 @@
  * compatibility (browsers able to understand gradient syntax support also SVG).
  * http://pauginer.tumblr.com/post/36614680636/invisible-gradient-technique */
 
-.wb-badge-featuredarticle {
+.wb-badge.wb-badge-featuredarticle {
 	background-image: url(../../images/wb-badges-gold.png);
 	/* @embed */
 	background-image: -webkit-linear-gradient(transparent, transparent), url(../../images/wb-badges-gold.svg);
@@ -19,7 +19,7 @@
 	background-image: linear-gradient(transparent, transparent), url(../../images/wb-badges-gold.svg);
 }
 
-.wb-badge-goodarticle {
+.wb-badge.wb-badge-goodarticle {
 	background-image: url(../../images/wb-badges-silver.png);
 	/* @embed */
 	background-image: -webkit-linear-gradient(transparent, transparent), url(../../images/wb-badges-silver.svg);


### PR DESCRIPTION
The current solution depends on the fact that this css rules get loaded after Wikibase.git ones. However, this is no longer true so we have to make more specific selectors to override the default icon rule.
